### PR TITLE
fix trivy json import fail with unknown properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,15 @@ target/
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
+#eclipse project files
+.settings/
+.project
+.classpath
+
 #IntelliJ project files
 .idea
 *.iml
 /.env
 out
+
+.factorypath

--- a/src/main/java/uk/gov/justice/digital/sonar/plugin/containercheck/model/Vulnerability.java
+++ b/src/main/java/uk/gov/justice/digital/sonar/plugin/containercheck/model/Vulnerability.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.sonar.plugin.containercheck.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Collection;
 import java.util.Collections;
@@ -18,6 +19,7 @@ import org.sonar.api.utils.log.Loggers;
 @ToString
 @EqualsAndHashCode
 @Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Vulnerability {
 
     private static final Logger LOGGER = Loggers.get(Vulnerability.class);


### PR DESCRIPTION
With the new version of trivy there is an additional field named "LayerID" which cause json import failure. I added ignore option for unknown properties (Also small git ignore files for eclipse IDE).

Sample json

```json
[
{
"Target": "alpine/git (alpine 3.11.5)",
"Vulnerabilities": [
{
"VulnerabilityID": "CVE-2020-1967",
"PkgName": "openssl",
"InstalledVersion": "1.1.1d-r3",
"FixedVersion": "1.1.1g-r0",
"LayerID": "sha256:aad63a9339440e7c3e1fff2b988991b9bfb81280042fa7f39a5e327023056819",
"Title": "openssl: Segmentation fault in SSL_check_chain causes denial of service",
"Description": "Server or client applications that call the SSL_check_chain() function during or after a TLS 1.3 handshake may crash due to a NULL pointer dereference as a result of incorrect handling of the \"signature_algorithms_cert\" TLS extension. The crash occurs if an invalid or unrecognised signature algorithm is received from the peer. This could be exploited by a malicious peer in a Denial of Service attack. OpenSSL version 1.1.1d, 1.1.1e, and 1.1.1f are affected by this issue. This issue did not affect OpenSSL versions prior to 1.1.1d. Fixed in OpenSSL 1.1.1g (Affected 1.1.1d-1.1.1f).",
"Severity": "HIGH",
"References": [
"http://www.openwall.com/lists/oss-security/2020/04/22/2",
"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1967",
"https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=eb563247aef3e83dda7679c43f9649270462e5b1",
"https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44440",
"https://lists.apache.org/thread.html/r66ea9c436da150683432db5fbc8beb8ae01886c6459ac30c2cea7345@%3Cdev.tomcat.apache.org%3E",
"https://lists.apache.org/thread.html/r94d6ac3f010a38fccf4f432b12180a13fa1cf303559bd805648c9064@%3Cdev.tomcat.apache.org%3E",
"https://lists.apache.org/thread.html/r9a41e304992ce6aec6585a87842b4f2e692604f5c892c37e3b0587ee@%3Cdev.tomcat.apache.org%3E",
"https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/XVEP3LAK4JSPRXFO4QF4GG2IVXADV3SO/",
"https://security.FreeBSD.org/advisories/FreeBSD-SA-20:11.openssl.asc",
"https://security.gentoo.org/glsa/202004-10",
"https://security.netapp.com/advisory/ntap-20200424-0003/",
"https://www.debian.org/security/2020/dsa-4661",
"https://www.openssl.org/news/secadv/20200421.txt",
"https://www.synology.com/security/advisory/Synology_SA_20_05_OpenSSL"
]
}
]
}
]
```